### PR TITLE
Add ignorance of files generated by Windows and Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,42 @@
 # Created by https://www.gitignore.io/api/matlab,latex
 
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+
+
+### Linux ###
+*~
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
 ### OSX ###
 *.DS_Store
 .AppleDouble


### PR DESCRIPTION
# Explain what has been changed
Add file extensions that are automatically generated by Windows and Linux OS into gitignore file

# Explain why this change is being made
Prevent Git from constantly informing untracked unnecessary files in git status

# Provide links to any relevant tickets, articles or other resources
gitignore file is created using [https://www.gitignore.io/](url)